### PR TITLE
feat: add chat window open/close animation and fix phone button anima…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -228,14 +228,6 @@ chat-widget {
   transform: scale(1);
 }
 
-/* Floating Phone Button Animation (Out of sync with Chat Widget) */
-[class*="phoneButton"] {
-  animation: widget-sequence 30s infinite !important;
-  animation-delay: 15.1s !important;
-  /* Tiny offset to prevent identical sub-frame starts if any */
-  transform-origin: center center !important;
-  transition: transform 0.2s cubic-bezier(0.175, 0.885, 0.32, 1.275) !important;
-}
 
 @keyframes badge-appear {
   from {

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -330,7 +330,53 @@ export default async function RootLayout({ children }) {
                           /* Long Final Pause: 77-100% */
                           77%, 100% { transform: scale(1) rotate(0) translateY(0); }
                         }
+
+                        /* 6. Chat Window Enhancements (Resize & Animation) */
+                        .lc_text-widget--box {
+                          transition: transform 1s cubic-bezier(0.16, 1, 0.3, 1), opacity 1s ease, width 1s ease, height 1s ease !important;
+                          transform: translateY(20px) !important;
+                          opacity: 0 !important;
+                          transform-origin: bottom right !important;
+                          display: flex !important;
+                          flex-direction: column !important;
+                        }
+
+                        .lc_text-widget--box.active {
+                          transform: translateY(0) scale(1) !important;
+                          opacity: 1 !important;
+                          visibility: visible !important;
+                        }
+                        .lc_text-widget {
+                          transition: all 1s ease !important;
+                        }
+                        .lc_text-widget--mobile {
+                          width: 100vw !important;
+                          height: 100vh !important;
+                          top: 0 !important;
+                          left: 0 !important;
+                          right: 0 !important;
+                          bottom: 0 !important;
+                          padding-bottom: 0px !important;
+                        }
                         
+                        /* Ensure the content inside doesn't overflow */
+                        .lc_text-widget--mobile .lc_text-widget--box .lc_text-widget_content {
+                          width: 100% !important;
+                        }
+                        .lc_text-widget--mobile .lc_text-widget_heading--root {
+                          border-radius: 0 !important;
+                        }
+                        @media (any-pointer: coarse) {
+                          .lc_text-widget {
+                            width: 100vw !important;
+                            height: 100vh !important;
+                            top: 0 !important;
+                            left: 0 !important;
+                            right: 0 !important;
+                            bottom: 0 !important;
+                            padding-bottom: 0px !important;
+                          }
+                        }
                         button, .chat-widget-button, .chip-button {
                           animation: widget-sequence 30s infinite !important;
                           transform-origin: center center !important;

--- a/src/modals/ExitIntentModal/ExitIntentModal.js
+++ b/src/modals/ExitIntentModal/ExitIntentModal.js
@@ -105,7 +105,6 @@ const ExitIntentModal = () => {
                     <div className={styles.footer}>
                         <Checkbox label={<TermsText />} />
                         <Button
-                            type="submit"
                             variant="primary"
                             className={styles.submitBtn}
                             disabled={isSubmitting || !formData.name || !validatePhone(formData.phone)}

--- a/src/ui/Header/Header.module.css
+++ b/src/ui/Header/Header.module.css
@@ -154,13 +154,12 @@ button.menuButton {
 
   .phoneButton.phoneButton {
     width: 58px;
-    /* Slightly larger to be consistent with chat widget */
     height: 58px;
     display: inline-flex !important;
     position: fixed;
     bottom: 84px;
     right: 20px;
-    z-index: 999;
+    z-index: 1000;
     border-radius: 50%;
     background-color: var(--green);
     color: var(--white);
@@ -169,7 +168,106 @@ button.menuButton {
     justify-content: center;
     transition: transform 0.2s, background-color 0.2s, box-shadow 0.2s;
 
+    /* Animation sequence (defined locally below) */
+    animation: phone-sequence 30s infinite !important;
+    animation-delay: -15s !important;
+    /* Start halfway immediately so user sees it sooner */
     transform-origin: center center !important;
+  }
+
+  @keyframes phone-sequence {
+
+    /* cycle is 30s total */
+    /* Wiggle: 0-2s (0-7%) */
+    0%,
+    6% {
+      transform: scale(1) rotate(0);
+    }
+
+    1% {
+      transform: scale(1.2) rotate(15deg);
+    }
+
+    2% {
+      transform: scale(1.2) rotate(-15deg);
+    }
+
+    3% {
+      transform: scale(1.2) rotate(15deg);
+    }
+
+    4% {
+      transform: scale(1.2) rotate(-15deg);
+    }
+
+    5% {
+      transform: scale(1.2) rotate(15deg);
+    }
+
+    /* Long Pause: 7-32% */
+    7%,
+    32% {
+      transform: scale(1) rotate(0);
+    }
+
+    /* Tada: 33-40% */
+    33% {
+      transform: scale(1);
+    }
+
+    34%,
+    35% {
+      transform: scale(0.9) rotate(-3deg);
+    }
+
+    36%,
+    37%,
+    38% {
+      transform: scale(1.3) rotate(3deg);
+    }
+
+    36.5%,
+    37.5%,
+    38.5% {
+      transform: scale(1.3) rotate(-3deg);
+    }
+
+    40% {
+      transform: scale(1) rotate(0);
+    }
+
+    /* Long Pause: 41-65% */
+    41%,
+    65% {
+      transform: scale(1) rotate(0);
+    }
+
+    /* Bounce: 66-73% */
+    66% {
+      transform: translateY(0);
+    }
+
+    68% {
+      transform: translateY(-20px);
+    }
+
+    70% {
+      transform: translateY(0);
+    }
+
+    72% {
+      transform: translateY(-10px);
+    }
+
+    73% {
+      transform: translateY(0);
+    }
+
+    /* Final Long Pause: 74-100% */
+    74%,
+    100% {
+      transform: scale(1) rotate(0) translateY(0);
+    }
   }
 
   .phoneButton:hover {


### PR DESCRIPTION
…tion

- Inject smooth open/close CSS animation for .lc_text-widget--box (fade + translateY, 1s ease)
- Add full-viewport styles for .lc_text-widget--mobile with (any-pointer: coarse) media query
- Move phone button animation to local @keyframes in Header.module.css (30s cycle, -15s delay)
- Remove global [class*="phoneButton"] animation from globals.css to avoid conflicts
- Fix ExitIntentModal submit button: remove type="submit" to prevent unintended native form submit
- Bump phone button z-index from 999 to 1000