### PR TITLE
This commit addresses Google Search Console indexing issues:

### DIFF
--- a/src/app/[city]/page.jsx
+++ b/src/app/[city]/page.jsx
@@ -50,6 +50,9 @@ export async function generateMetadata({ params }) {
             "addressRegion": state_code || "TX",
             "addressCountry": "US",
         },
+        alternates: {
+            canonical: `https://tvprousa.com/${citySlug}/`,
+        },
         openGraph: {
             title,
             description,
@@ -62,6 +65,7 @@ export async function generateMetadata({ params }) {
                 },
             ],
             type: 'website',
+            url: `https://tvprousa.com/${citySlug}/`,
         },
         twitter: {
             card: 'summary_large_image',

--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -96,7 +96,7 @@ Choose TV Pro Handy Services for fast, reliable, top-rated home theater installa
     },
   ],
   alternates: {
-    canonical: 'https://tvprousa.com',
+    canonical: 'https://tvprousa.com/',
   },
   openGraph: {
     title: 'TV Mounting Services | TVPro Handy Services',

--- a/src/app/sitemap.js
+++ b/src/app/sitemap.js
@@ -17,7 +17,7 @@ export default async function sitemap() {
     const cityEntries = cities
         .filter(city => !city.test_version && city.path)
         .map((city) => ({
-            url: `${baseUrl}/${city.path}`,
+            url: `${baseUrl}/${city.path}/`,
             lastModified: new Date(),
             changeFrequency: 'weekly',
             priority: 1,
@@ -26,25 +26,25 @@ export default async function sitemap() {
     // 3. Static routes
     const staticEntries = [
         {
-            url: baseUrl,
+            url: `${baseUrl}/`,
             lastModified: new Date(),
             changeFrequency: 'daily',
             priority: 1,
         },
         {
-            url: `${baseUrl}/privacy-policy`,
+            url: `${baseUrl}/privacy-policy/`,
             lastModified: new Date(),
             changeFrequency: 'monthly',
             priority: 0.3,
         },
         {
-            url: `${baseUrl}/terms`,
+            url: `${baseUrl}/terms/`,
             lastModified: new Date(),
             changeFrequency: 'monthly',
             priority: 0.3,
         },
         {
-            url: `${baseUrl}/sms-consent`,
+            url: `${baseUrl}/sms-consent/`,
             lastModified: new Date(),
             changeFrequency: 'monthly',
             priority: 0.3,


### PR DESCRIPTION
- "Alternate page with proper canonical tag": The global canonical URL in layout.js was causing all /[city] pages to report as duplicates of the homepage. Fixed by setting specific canonical URLs for each city page in page.jsx.
- "Page with redirect": Added trailing slashes to all sitemap URLs since Next.js static export is configured with trailingSlash: true. This prevents Googlebot from hitting 308 redirects.