### PR TITLE
feat(analytics): clean up tracking scripts and restore essential widgets

### DIFF
--- a/src/app/layout.js
+++ b/src/app/layout.js
@@ -202,37 +202,23 @@ export default async function RootLayout({ children }) {
                 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
                 })(window,document,'script','dataLayer','GTM-5QVX2Z6S');
 
-                // Meta Pixel
-                !function(f,b,e,v,n,t,s)
-                {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
-                n.callMethod.apply(n,arguments):n.queue.push(arguments)};
-                if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
-                n.queue=[];t=b.createElement(e);t.async=!0;
-                t.src=v;s=b.getElementsByTagName(e)[0];
-                s.parentNode.insertBefore(t,s)}(window, document,'script',
-                'https://connect.facebook.net/en_US/fbevents.js');
-                fbq('init', '809936758465245');
-                fbq('track', 'PageView');
-                
-                // Google Ads / GA4
-                var gtagScript = document.createElement('script');
-                gtagScript.async = true;
-                gtagScript.src = "https://www.googletagmanager.com/gtag/js?id=G-GZBG74J130";
-                document.head.appendChild(gtagScript);
-                
-                window.gtag = window.gtag || function() { (window.dataLayer = window.dataLayer || []).push(arguments); };
-                window.gtag('js', new Date());
-                window.gtag('config', 'G-GZBG74J130');
-                window.gtag('config', 'AW-17416148778');
-                window.gtag('config', 'AW-17416148778/cLquCL68mv8aEKqu1fBA', { 'phone_conversion_number': '(877) 455-5535' });
-
-                // Workiz tracking
+                // WhatConverts tracking
                 var workizLeads = {doc:{url:document.URL,ref:document.referrer,search:location.search,hash:location.hash}};
                 window.$wc_leads = JSON.parse(JSON.stringify(workizLeads));
                 var workizScript = document.createElement('script');
                 workizScript.async = true;
                 workizScript.src = "//s.ksrndkehqnwntyxlhgto.com/154265.js";
                 document.head.appendChild(workizScript);
+
+                // WhatConverts Chat tracking
+                window.$wc_leads = window.$wc_leads || [];
+                $wc_leads.track.chat({
+                  'First Name': 'Joe',
+                  'Last Name': 'Smith',
+                  'Email Address': 'joe.smith@example.com',
+                  'Phone Number': '+18883437185',
+                  'Chat Log': 'Visitor - Does your company offer unlimited ...'
+                });
 
                 // Thumbtack Star Widget
                 var ttScript = document.createElement('script');
@@ -456,12 +442,6 @@ export default async function RootLayout({ children }) {
           `}
         </Script>
 
-        <noscript>
-          <img height="1" width="1" style={{ display: 'none' }}
-            src="https://www.facebook.com/tr?id=809936758465245&ev=PageView&noscript=1"
-            alt=""
-          />
-        </noscript>
       </head>
       <body className={redHatDisplay.variable}>
         <CTAProvider initialCTA={cta}>

--- a/src/modals/BookNowModal/BookNowModal.js
+++ b/src/modals/BookNowModal/BookNowModal.js
@@ -70,6 +70,11 @@ const BookNowModal = () => {
         setIsSubmitting(true);
         try {
             const apiUrl = process.env.NEXT_PUBLIC_SRTAPI_URL || 'http://localhost:1337';
+
+            const path = window.location.pathname;
+            const pathParts = path.split('/').filter(part => part !== "");
+
+            const city = pathParts[0];
             const response = await fetch(`${apiUrl}/api/book-now`, {
                 method: 'POST',
                 headers: {
@@ -79,6 +84,8 @@ const BookNowModal = () => {
                     data: {
                         name: formData.name,
                         phone: formData.phone,
+                        source: 'book-now-modal',
+                        city,
                         ...getUtmParams(),
                     }
                 }),

--- a/src/modals/ExitIntentModal/ExitIntentModal.js
+++ b/src/modals/ExitIntentModal/ExitIntentModal.js
@@ -58,6 +58,12 @@ const ExitIntentModal = () => {
         setIsSubmitting(true);
         try {
             const apiUrl = process.env.NEXT_PUBLIC_SRTAPI_URL || 'http://localhost:1337';
+            const path = window.location.pathname;
+
+            const pathParts = path.split('/').filter(part => part !== "");
+
+            const city = pathParts[0];
+
             const response = await fetch(`${apiUrl}/api/book-now`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -67,6 +73,7 @@ const ExitIntentModal = () => {
                         phone: formData.phone,
                         source: 'exit_intent_popup',
                         ...getUtmParams(),
+                        city
                     }
                 }),
             });


### PR DESCRIPTION
- Keep GTM-5QVX2Z6S, WhatConverts (wc), Microsoft Clarity, Thumbtack, and LeadConnector Chat Widget.
- Remove Facebook Pixel, Google Ads, and GA4.
- Add new WhatConverts chat tracking script ($wc_leads.track.chat).
- Fix syntax error in layout.js by escaping nested template literals.